### PR TITLE
Better support history.back

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@ import Link from 'next/link';
 import { useContextualRouting } from 'next-use-contextual-routing';
 
 function MyPage() {
-  const { returnHref, contextualHref } = useContextualRouting();
+  const { makeContextualHref, returnHref } = useContextualRouting();
 
   return (
     <ul>
       <li>
-        <Link href={contextualHref} as="/route-to-visit-contextually" shallow>
+        <Link
+          href={makeContextualHref({ id: 33 })}
+          as="/route-to-visit-contextually"
+          shallow
+        >
           Start contextual routing
         </Link>
       </li>
@@ -36,23 +40,25 @@ function MyPage() {
 ### With Next router
 
 ```js
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useRouter } from 'next/link';
 import { useContextualRouting } from 'next-use-contextual-routing';
 
 function MyPage() {
   const router = useRouter();
-  const { returnHref, contextualHref } = useContextualRouting();
+  const { makeContextualHref, returnHref } = useContextualRouting();
 
-  const openModal = useCallback(() => {
-    router.push(contextualHref, '/route-to-visit-contextually', {
-      shallow: true,
-    });
-  }, [router, contextualHref]);
+  const openModal = () =>
+    router.push(
+      makeContextualHref({ id: 33 }),
+      '/route-to-visit-contextually',
+      {
+        shallow: true,
+      }
+    );
 
-  const closeModal = useCallback(() => {
+  const closeModal = () =>
     router.push(returnHref, undefined, { shallow: true });
-  }, [router, returnHref]);
 
   return (
     <ul>
@@ -66,6 +72,39 @@ function MyPage() {
   );
 }
 ```
+
+## Why?
+
+Contextual routing presents 2 challenges:
+
+- Persist a href string able to keep the initial page state consistent throughout the whole contextual navigation
+- Persist the url to return to when contextual routing is terminated
+
+**Next use contextual routing** abstracts these responsibilities in the form of a React hook.
+
+## API
+
+```js
+const { makeContextualHref, returnHref } = useContextualRouting();
+```
+
+#### makeContextualHref
+
+```js
+const makeContextualHref: (extraQueryParams: { [key: string]: any }) => string;
+```
+
+The function returns the path to provide as `href` to start or keep alive contextual navigation. The generated path describes the state of the page to keep alive while contextual navigation is active.
+
+It optionally accepts an object describing **extra parameters** to append to contextual navigation `href`.
+
+#### returnHref
+
+```js
+const returnHref: string;
+```
+
+The path to return to to close contextual navigation.
 
 ## Notes
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,25 @@
+const test = process.env.NODE_ENV === 'test';
+module.exports = (api) => {
+  api.cache(false);
+  return {
+    presets: [
+      [
+        '@babel/env',
+        {
+          modules: test ? 'cjs' : false,
+          loose: true,
+        },
+      ],
+    ],
+    plugins: test
+      ? [
+          [
+            '@babel/plugin-transform-react-jsx',
+            {
+              useBuiltIns: true,
+            },
+          ],
+        ]
+      : [],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
+    "@babel/plugin-transform-react-jsx": "^7.10.4",
+    "@babel/preset-env": "^7.11.5",
     "@rollup/plugin-babel": "^5.2.1",
     "@testing-library/react-hooks": "^3.4.1",
     "coveralls": "^3.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,6 @@ export default [
       { file: pkg.main, format: 'cjs' },
       { file: pkg.module, format: 'es' },
     ],
-    plugins: [babel({ babelHelpers: 'runtime' })],
+    plugins: [babel({ babelHelpers: 'bundled' })],
   },
 ];

--- a/src/__tests__/index.test-d.ts
+++ b/src/__tests__/index.test-d.ts
@@ -1,8 +1,10 @@
-import { expectType } from 'tsd';
+import { expectType, expectAssignable, expectError } from 'tsd';
 import { useContextualRouting } from '../';
 
-type expected = {
-  returnHref: string;
-  contextualHref: string;
-};
-expectType<expected>(useContextualRouting());
+const { returnHref, makeContextualHref } = useContextualRouting();
+
+expectType<string>(returnHref);
+expectAssignable<Function>(makeContextualHref);
+
+expectError(makeContextualHref('s'));
+expectType<string>(makeContextualHref({ foo: 'bar' }));

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,6 @@
 export function useContextualRouting(): {
   returnHref: string;
-  contextualHref: string;
+  makeContextualHref: (extraQueryParams: { [key: string]: any }) => string;
 };
+
+

--- a/src/index.js
+++ b/src/index.js
@@ -14,10 +14,11 @@ export const RETURN_HREF_QUERY_PARAM = '_UCR_return_href';
  */
 export function useContextualRouting() {
   const router = useRouter();
-  const {
-    [RETURN_HREF_QUERY_PARAM]: returnHrefQueryParam,
-    ...watchedQuery
-  } = router.query;
+  const returnHrefQueryParam = router.query[RETURN_HREF_QUERY_PARAM];
+  const watchedQuery = {
+    ...router.query,
+  };
+  delete watchedQuery[RETURN_HREF_QUERY_PARAM];
 
   /*
    * After a page refresh there is no RETURN_HREF_QUERY_PARAM in router.query


### PR DESCRIPTION
## What kind of change does this PR introduce?

Better support for history.back.

## What is the current behaviour?

The current solution doesn't cover some scenarios involving pushing back browser's history.

## What is the new behaviour?

Store `returnPath` into route.query object.

Next's keeps a copy of `router.query` into browser's history state,  which we can use to retrieve the url where contextual routing started from.

## Does this PR introduce a breaking change?

Yes. `contextualHref` is replaced by `makeContextualHref` function which also provide support for extra params to start contextual navigation with.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
