### PR TITLE
Support without manually adding the query params in both 'as' and 'href' attributes.

### DIFF
--- a/demo/components/PostGrid.js
+++ b/demo/components/PostGrid.js
@@ -4,15 +4,14 @@ import { useContextualRouting } from 'src';
 export const data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 export default function PostGrid({ small }) {
-  const { makeContextualHref } = useContextualRouting();
+  const { makeContextualLink } = useContextualRouting();
 
   return (
     <Grid small={small}>
       {data.map((id, index) => (
         <SquaredLink
           key={index}
-          href={makeContextualHref({ postId: id })}
-          as={`/post/${id}`}
+          {...makeContextualLink(`/post/${id}`)}
         >
           {id}
         </SquaredLink>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,8 @@
+import { UrlObject  } from 'url';
+
 export function useContextualRouting(): {
   returnHref: string;
-  makeContextualHref: (extraQueryParams: { [key: string]: any }) => string;
+  makeContextualLink: (url: string | UrlObject) => string;
 };
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/router';
-import stringify from 'qs-stringify';
+import QueryString from 'qs';
+
 export const RETURN_HREF_QUERY_PARAM = '_UCR_return_href';
 
 /**
@@ -26,17 +27,22 @@ export function useContextualRouting() {
   const returnHref = returnHrefQueryParam ?? router.asPath;
   // @NOTE JSON.stringify might be replaced with any hashing solution
   const queryHash = JSON.stringify(watchedQuery);
-  const makeContextualHref = useCallback(
-    (extraParams) =>
-      router.pathname +
-      '?' +
-      stringify(
-        Object.assign({}, router.query, extraParams, {
-          [RETURN_HREF_QUERY_PARAM]: returnHref,
-        })
-      ),
+  const makeContextualLink = useCallback(
+    (url) => {
+      url = require('url').format(url);
+      const extraParams = QueryString.parse(url.substring(url.indexOf("?") + 1));
+
+      const linkProps = {
+        as: url,
+        href: router.pathname + '?' + QueryString.stringify(
+          Object.assign({}, extraParams, { [RETURN_HREF_QUERY_PARAM]: returnHref })
+        )
+      };
+
+      return linkProps;
+    },
     [queryHash, returnHref]
   );
 
-  return { returnHref, makeContextualHref };
+  return { returnHref, makeContextualLink };
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

It add support without manually adding the query params in both 'as' and 'href' attributes.

## What is the current behaviour?

When making a contextual href, You'll need to pass some query params in href with relation to the as attribute.

## What is the new behaviour?
No need for the double work anymore, Everything is handled within.

## Does this PR introduce a breaking change?
Yes, You need to pass only a single url to enable the contextual routing

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
