### PR TITLE
refactor: remove qs-stringify dependency

### DIFF
--- a/.changeset/unlucky-seahorses-taste.md
+++ b/.changeset/unlucky-seahorses-taste.md
@@ -1,0 +1,5 @@
+---
+'next-use-contextual-routing': minor
+---
+
+refactor: remove qs-stringify dependency in favour of native URLSearchParams

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "next-use-contextual-routing",
       "version": "3.2.0",
       "license": "ISC",
-      "dependencies": {
-        "qs-stringify": "^1.2.1"
-      },
       "devDependencies": {
         "@changesets/cli": "^2.27.7",
         "@testing-library/react": "^16.0.0",
@@ -20,6 +17,7 @@
         "jest-environment-jsdom": "^29.3.1",
         "next": "^15.0.0",
         "prettier": "^3.3.2",
+        "qs-stringify": "^1.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-modal": "^3.16.1",
@@ -5248,7 +5246,8 @@
     "node_modules/qs-stringify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/qs-stringify/-/qs-stringify-1.2.1.tgz",
-      "integrity": "sha512-2N5xGLGZUxpgAYq1fD1LmBSCbxQVsXYt5JU0nU3FuPWO8PlCnKNFQwXkZgyB6mrTdg7IbexX4wxIR403dJw9pw=="
+      "integrity": "sha512-2N5xGLGZUxpgAYq1fD1LmBSCbxQVsXYt5JU0nU3FuPWO8PlCnKNFQwXkZgyB6mrTdg7IbexX4wxIR403dJw9pw==",
+      "dev": true
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -10181,7 +10180,8 @@
     "qs-stringify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/qs-stringify/-/qs-stringify-1.2.1.tgz",
-      "integrity": "sha512-2N5xGLGZUxpgAYq1fD1LmBSCbxQVsXYt5JU0nU3FuPWO8PlCnKNFQwXkZgyB6mrTdg7IbexX4wxIR403dJw9pw=="
+      "integrity": "sha512-2N5xGLGZUxpgAYq1fD1LmBSCbxQVsXYt5JU0nU3FuPWO8PlCnKNFQwXkZgyB6mrTdg7IbexX4wxIR403dJw9pw==",
+      "dev": true
     },
     "querystringify": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
   },
   "author": "Andrea Carraro <me@andreacarraro.it>",
   "license": "ISC",
-  "dependencies": {
-    "qs-stringify": "^1.2.1"
-  },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",
     "@testing-library/react": "^16.0.0",
@@ -55,6 +52,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "next": "^15.0.0",
     "prettier": "^3.3.2",
+    "qs-stringify": "^1.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-modal": "^3.16.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/router.js';
-import stringify from 'qs-stringify';
 export const RETURN_HREF_QUERY_PARAM = '_UCR_return_href';
 
 /**
@@ -36,11 +35,11 @@ export function useContextualRouting(): {
     (extraParams?: Record<string, string | number>) =>
       router.pathname +
       '?' +
-      stringify(
-        Object.assign({}, router.query, extraParams, {
-          [RETURN_HREF_QUERY_PARAM]: returnHref,
-        })
-      ),
+      new URLSearchParams({
+        ...router.query,
+        ...extraParams,
+        [RETURN_HREF_QUERY_PARAM]: returnHref,
+      }).toString(),
     [queryHash, returnHref]
   );
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the new behaviour?

Generate with native `URLSearchParams` instead of `qs-stringify`.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
