### PR TITLE
chore: use fastify/github-action-merge-dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,9 +7,10 @@ jobs:
   dependabot-auto-merge:
     name: 'Dependabot auto merge'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: fastify/github-action-merge-dependabot@v3
         with:
           target: minor
-          github-token: ${{ secrets.READ_AND_WRITE_TOKEN }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore:

## What is the current behaviour?

https://github.com/marketplace/actions/dependabot-auto-merge seems not to support dependabot groups updates.

## What is the new behaviour?

Try https://github.com/fastify/github-action-merge-dependabot

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
